### PR TITLE
blueprint: Use Infrastructure constructor

### DIFF
--- a/elasticsearchExample.js
+++ b/elasticsearchExample.js
@@ -1,13 +1,13 @@
-const { createDeployment, Machine } = require('kelda');
+const { Infrastructure, Machine } = require('kelda');
 const Elasticsearch = require('./elasticsearch.js').Elasticsearch;
 
 const clusterSize = 2;
 
-const deployment = createDeployment({});
 const baseMachine = new Machine({ provider: 'Amazon' });
-deployment.deploy(baseMachine.asMaster());
-deployment.deploy(baseMachine.asWorker().replicate(clusterSize));
+const infra = new Infrastructure(
+  baseMachine,
+  baseMachine.replicate(clusterSize));
 
 const elasticsearch = new Elasticsearch(clusterSize);
 elasticsearch.allowFromPublic();
-elasticsearch.deploy(deployment);
+elasticsearch.deploy(infra);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./elasticsearch.js",
   "license": "MIT",
   "dependencies": {
-    "kelda": "0.x"
+    "kelda": ">=0.0.5 <1.0.0"
   },
   "devDependencies": {
     "eslint": "^4.3.0",


### PR DESCRIPTION
This commit replaces the deprecated `createDeployment` function with the
new `Infrastructure` constructor.