### PR TITLE
blueprint: Remove use of deprecated functions

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -34,7 +34,7 @@ function Elasticsearch(n) {
 }
 
 Elasticsearch.prototype.uri = function uri() {
-  return `http://${this.loadBalancer.hostname()}:${this.port}`;
+  return `http://${this.loadBalancer.getHostname()}:${this.port}`;
 };
 
 Elasticsearch.prototype.allowFromPublic = function allowFromPublic() {

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -7,14 +7,19 @@ function getHostname(c) {
 function Elasticsearch(n) {
   this.containers = [];
   for (let i = 0; i < n; i += 1) {
-    this.containers.push(new kelda.Container('elasticsearch', 'elasticsearch:2.4', {
+    this.containers.push(new kelda.Container({
+      name: 'elasticsearch',
+      image: 'elasticsearch:2.4',
       command: [
         '--transport.tcp.port', `${this.transportPorts.min}-${this.transportPorts.max}`,
         '--http.port', this.port.toString(),
       ],
     }));
   }
-  this.loadBalancer = new kelda.LoadBalancer('elasticsearch-lb', this.containers);
+  this.loadBalancer = new kelda.LoadBalancer({
+    name: 'elasticsearch-lb',
+    containers: this.containers,
+  });
 
   if (n > 1) {
     const hosts = this.containers.map(getHostname).join(',');

--- a/elasticsearchExample.js
+++ b/elasticsearchExample.js
@@ -4,9 +4,10 @@ const Elasticsearch = require('./elasticsearch.js').Elasticsearch;
 const clusterSize = 2;
 
 const baseMachine = new Machine({ provider: 'Amazon' });
-const infra = new Infrastructure(
-  baseMachine,
-  baseMachine.replicate(clusterSize));
+const infra = new Infrastructure({
+  masters: baseMachine,
+  workers: baseMachine.replicate(clusterSize),
+});
 
 const elasticsearch = new Elasticsearch(clusterSize);
 elasticsearch.allowFromPublic();


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.